### PR TITLE
Cambiar la masa y velocidad de los ratones

### DIFF
--- a/Assets/Animations/Enemies/FoodMonster/FoodMonsterLeftoversAnimatorController.controller
+++ b/Assets/Animations/Enemies/FoodMonster/FoodMonsterLeftoversAnimatorController.controller
@@ -35,7 +35,7 @@ AnimatorStateTransition:
   m_Name: 
   m_Conditions:
   - m_ConditionMode: 1
-    m_ConditionEvent: Explote
+    m_ConditionEvent: muerte
     m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -8933064126179837756}
@@ -85,12 +85,12 @@ AnimatorController:
   m_Name: FoodMonsterLeftoversAnimatorController
   serializedVersion: 5
   m_AnimatorParameters:
-  - m_Name: Explote
+  - m_Name: muerte
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Levels_Designs/Lvl2/Scene/Lvl02WorldBuilding.unity
+++ b/Assets/Levels_Designs/Lvl2/Scene/Lvl02WorldBuilding.unity
@@ -1147,7 +1147,7 @@ PrefabInstance:
     - target: {fileID: 8802494108255672137, guid: 3c9a9ff1ac55cbb4789682f70ad88512,
         type: 3}
       propertyPath: m_RootOrder
-      value: 6
+      value: 7
       objectReference: {fileID: 0}
     - target: {fileID: 8802494108255672137, guid: 3c9a9ff1ac55cbb4789682f70ad88512,
         type: 3}
@@ -1772,7 +1772,7 @@ PrefabInstance:
     - target: {fileID: 4845206870327834096, guid: 44662aaa48dd3a240a774d36a8774e26,
         type: 3}
       propertyPath: m_RootOrder
-      value: 11
+      value: 12
       objectReference: {fileID: 0}
     - target: {fileID: 4845206870327834096, guid: 44662aaa48dd3a240a774d36a8774e26,
         type: 3}
@@ -2450,7 +2450,7 @@ PrefabInstance:
     - target: {fileID: 8802494108255672137, guid: 3c9a9ff1ac55cbb4789682f70ad88512,
         type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 8802494108255672137, guid: 3c9a9ff1ac55cbb4789682f70ad88512,
         type: 3}
@@ -4060,7 +4060,7 @@ PrefabInstance:
     - target: {fileID: 7775396579342121294, guid: 66b6500a25c07b14f8ec403e9c9ecca9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 8
+      value: 9
       objectReference: {fileID: 0}
     - target: {fileID: 7775396579342121294, guid: 66b6500a25c07b14f8ec403e9c9ecca9,
         type: 3}
@@ -17626,7 +17626,7 @@ PrefabInstance:
     - target: {fileID: 7775396579342121294, guid: 66b6500a25c07b14f8ec403e9c9ecca9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 10
+      value: 11
       objectReference: {fileID: 0}
     - target: {fileID: 7775396579342121294, guid: 66b6500a25c07b14f8ec403e9c9ecca9,
         type: 3}
@@ -26299,7 +26299,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1898057356
 MonoBehaviour:
@@ -26358,7 +26358,7 @@ PrefabInstance:
     - target: {fileID: 7775396579342121294, guid: 66b6500a25c07b14f8ec403e9c9ecca9,
         type: 3}
       propertyPath: m_RootOrder
-      value: 5
+      value: 6
       objectReference: {fileID: 0}
     - target: {fileID: 7775396579342121294, guid: 66b6500a25c07b14f8ec403e9c9ecca9,
         type: 3}
@@ -26761,7 +26761,7 @@ PrefabInstance:
     - target: {fileID: 1490733678685402930, guid: c45bb2a23970d7342a3b00473242d3e3,
         type: 3}
       propertyPath: m_RootOrder
-      value: 9
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1490733678685402930, guid: c45bb2a23970d7342a3b00473242d3e3,
         type: 3}

--- a/Assets/Personajes/prefabs/MOUSE ENEMY.prefab
+++ b/Assets/Personajes/prefabs/MOUSE ENEMY.prefab
@@ -217,7 +217,7 @@ MonoBehaviour:
   position_2: {fileID: 911555215511096916}
   position_3: {fileID: 8315709934325314870}
   position_4: {fileID: 4903933057043350672}
-  moveSpeed: 0.15
+  moveSpeed: 4
   ildeTime: 4
 --- !u!95 &4036657779734173099
 Animator:
@@ -250,9 +250,9 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 0.5
-  m_LinearDrag: 0
-  m_AngularDrag: 0.5
+  m_Mass: 3
+  m_LinearDrag: 1
+  m_AngularDrag: 0
   m_GravityScale: 0
   m_Material: {fileID: 0}
   m_Interpolate: 0

--- a/Assets/Personajes/prefabs/MOUSE ENEMY.prefab
+++ b/Assets/Personajes/prefabs/MOUSE ENEMY.prefab
@@ -217,7 +217,7 @@ MonoBehaviour:
   position_2: {fileID: 911555215511096916}
   position_3: {fileID: 8315709934325314870}
   position_4: {fileID: 4903933057043350672}
-  moveSpeed: 0.15
+  moveSpeed: 5
   ildeTime: 4
 --- !u!95 &4036657779734173099
 Animator:
@@ -250,9 +250,9 @@ Rigidbody2D:
   m_Simulated: 1
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
-  m_Mass: 0.5
-  m_LinearDrag: 0
-  m_AngularDrag: 0.5
+  m_Mass: 1
+  m_LinearDrag: 2.8
+  m_AngularDrag: 0
   m_GravityScale: 0
   m_Material: {fileID: 0}
   m_Interpolate: 0

--- a/Assets/Scripts/Leftovers.cs
+++ b/Assets/Scripts/Leftovers.cs
@@ -19,7 +19,7 @@ public class Leftovers : Enemy
     IEnumerator Explote()
     {
         yield return new WaitForSeconds(exploteTime);
-        enemyAnimator.SetTrigger("Explote");
+        enemyAnimator.SetTrigger("muerte");
         StartCoroutine(stats.Die());
     }
 }


### PR DESCRIPTION
Cambiar la masa y velocidad de los ratones, ya es más controlable y se cambio el nombre de los triggers de los restos de comida al explotar